### PR TITLE
feat: 평가계획 조회에 학기·학년·과목 지정 추가 (get_evaluation_plan)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schoolinfo-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schoolinfo-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -2364,7 +2364,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2454,7 +2453,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2764,7 +2762,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3303,7 +3300,6 @@
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
       "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -3324,7 +3320,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4097,7 +4092,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -4645,7 +4639,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4724,7 +4717,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/evaluation.ts
+++ b/src/evaluation.ts
@@ -34,16 +34,50 @@ async function fetchT(url: string, init: RequestInit = {}, timeout = FETCH_TIMEO
   return fetchWithRetry(url, init, { timeout, label: "학교알리미" });
 }
 
-// "교과별(학년별) 교수·학습 및 평가계획에 관한 사항" 공시항목 고정 코드
-// (학교알리미 공시항목 자체의 분류 코드 — 모든 학교 공통)
-const EVAL_ITEM = {
-  GS_HANGMOK_CD: "43",
-  GS_HANGMOK_NO: "4-가",
-  GS_HANGMOK_NM: "교과별(학년별) 교수ㆍ학습 및 평가계획에 관한 사항",
-  GS_BURYU_CD: "JG110",
-  JG_BURYU_CD: "JG040",
-  JG_HANGMOK_CD: "14",
-  JG_GUBUN: "1",
+/**
+ * 공시항목별 첨부파일 다운로드 명세.
+ * 다운로드 메커니즘(POST b페이지 → 첨부목록 → EiFileDownLoad.do → kordoc)은 동일하고
+ * **항목 코드/엔드포인트만** 항목마다 다르다 (코드는 학교알리미 공시항목 분류 — 전국·전학교급 공통).
+ */
+export interface DisclosureItemSpec {
+  /** 항목 조회 POST 엔드포인트 (/ei/pp/ 하위). 엔드포인트 번호 = GS_HANGMOK_CD */
+  endpoint: string;
+  /** 공시항목 고정 코드 (POST body + 다운로드 파라미터 폴백) */
+  codes: {
+    GS_HANGMOK_CD: string; GS_HANGMOK_NO: string; GS_HANGMOK_NM: string;
+    GS_BURYU_CD: string; JG_BURYU_CD: string; JG_HANGMOK_CD: string; JG_GUBUN: string;
+  };
+  /** 첨부파일 우선순위 점수 (낮을수록 우선) — 한 항목에 파일이 여럿일 때 본문 파일 선별 */
+  score: (filename: string) => number;
+  /** 변환 마크다운에서 뽑아낼 관심 섹션 키워드 */
+  sectionKeywords: string[];
+}
+
+const EVAL_SECTION_KEYWORDS = ["수행평가", "평가기준", "평가요소", "평가방법", "평가영역", "반영비율", "평가시기", "성취기준", "지필", "정기시험"];
+const CURRICULUM_SECTION_KEYWORDS = ["편제", "이수단위", "이수 단위", "단위 배당", "학점 배당", "시간 배당", "교과(군)", "창의적 체험활동", "학년군", "기준 단위"];
+
+/** 4-가. 교과별(학년별) 교수·학습 및 평가 운영 계획 (= 수행평가 주제·평가기준) */
+export const EVAL_ITEM_SPEC: DisclosureItemSpec = {
+  endpoint: "Pneipp_b43_s0p.do",
+  codes: {
+    GS_HANGMOK_CD: "43", GS_HANGMOK_NO: "4-가",
+    GS_HANGMOK_NM: "교과별(학년별) 교수ㆍ학습 및 평가계획에 관한 사항",
+    GS_BURYU_CD: "JG110", JG_BURYU_CD: "JG040", JG_HANGMOK_CD: "14", JG_GUBUN: "1",
+  },
+  score: evalScore,
+  sectionKeywords: EVAL_SECTION_KEYWORDS,
+};
+
+/** 2-가. 학교교육과정 편성·운영 및 평가에 관한 사항 (= 교육과정 편제표) */
+export const CURRICULUM_ITEM_SPEC: DisclosureItemSpec = {
+  endpoint: "Pneipp_b14_s0p.do",
+  codes: {
+    GS_HANGMOK_CD: "14", GS_HANGMOK_NO: "2-가",
+    GS_HANGMOK_NM: "학교교육과정 편성ㆍ운영 및 평가에 관한 사항",
+    GS_BURYU_CD: "JG100", JG_BURYU_CD: "JG020", JG_HANGMOK_CD: "05", JG_GUBUN: "1",
+  },
+  score: curriculumScore,
+  sectionKeywords: CURRICULUM_SECTION_KEYWORDS,
 };
 
 export interface EvaluationFile {
@@ -52,15 +86,43 @@ export interface EvaluationFile {
   sizeKB?: number;
 }
 
+/**
+ * 학교알리미 "자료제출일" 드롭다운(#select_trans_dt)의 한 항목 — 실제 제출 회차.
+ * value="{JG_YEAR}{JG_CHASU}" 형태(예: "20253" = 2025년 3차)를 그대로 분해한 것.
+ * 관찰상 1차=4월(1학기), 3차=9월(2학기) 패턴이나, 학교/연도별 예외 가능성을 감안해
+ * "그 해 최소 chasu=1학기, 최대 chasu=2학기"로 일반화해 판단한다 (하드코딩 1/3 지양).
+ */
+export interface SubmissionRound {
+  year: number;
+  chasu: number;
+  label: string; // 예: "(3차) 2025년 09월"
+  selected: boolean;
+}
+
+/** #select_trans_dt 드롭다운에서 제출 회차 목록을 파싱한다 */
+function parseSubmissionRounds(html: string): SubmissionRound[] {
+  const sel = html.match(/<select[^>]*id="select_trans_dt"[^>]*>([\s\S]*?)<\/select>/i);
+  if (!sel) return [];
+  const rounds: SubmissionRound[] = [];
+  const re = /<option\s+value="(\d{4})(\d+)"\s*(selected)?\s*>\s*([^<]*)<\/option>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sel[1]))) {
+    rounds.push({ year: Number(m[1]), chasu: Number(m[2]), label: m[4].trim(), selected: !!m[3] });
+  }
+  return rounds;
+}
+
 /** 평가계획 첨부파일 목록 + 다운로드 파라미터 조회 (POST b43) */
 export async function fetchEvaluationFiles(
   shlIdfCd: string,
   schoolName: string,
-  year = new Date().getFullYear()
-): Promise<{ files: EvaluationFile[]; downloadParams: Record<string, string> }> {
+  year = new Date().getFullYear(),
+  spec: DisclosureItemSpec = EVAL_ITEM_SPEC,
+  chasu?: number
+): Promise<{ files: EvaluationFile[]; downloadParams: Record<string, string>; rounds: SubmissionRound[] }> {
   if (!shlIdfCd) throw new Error("학교고유식별코드(SHL_IDF_CD)가 없습니다.");
   const body = new URLSearchParams({
-    ...EVAL_ITEM,
+    ...spec.codes,
     HG_NM: schoolName,
     SHL_IDF_CD: shlIdfCd,
     GS_TYPE: "Y",
@@ -70,8 +132,10 @@ export async function fetchEvaluationFiles(
     PRE_JG_YEAR: String(year),
     LOAD_TYPE: "single",
   });
+  // 회차(학기) 미지정 시 서버가 최신 제출분을 기본으로 준다 — 특정 학기가 필요하면 명시해야 함.
+  if (chasu != null) body.set("JG_CHASU", String(chasu));
 
-  const res = await fetchT(`${BASE}/ei/pp/Pneipp_b43_s0p.do`, {
+  const res = await fetchT(`${BASE}/ei/pp/${spec.endpoint}`, {
     method: "POST",
     headers: {
       "User-Agent": UA,
@@ -89,9 +153,13 @@ export async function fetchEvaluationFiles(
   // 첨부파일 목록: getEiFile43('N') + 파일명.확장자(NN KB)
   const files = parseFileList(html);
   // 다운로드 폼 파라미터 (eiFileDownForm hidden)
-  const downloadParams = parseDownloadParams(html, shlIdfCd, year);
+  const downloadParams = parseDownloadParams(html, shlIdfCd, year, spec);
+  // 자료제출일(회차) 드롭다운 — 몇 차까지 제출됐는지, 어느 회차가 1/2학기인지 판단용
+  const rounds = parseSubmissionRounds(html);
+  // 실제 반영된 회차값으로 다운로드 파라미터 보정 (요청한 chasu가 있으면 그걸로 확정)
+  if (chasu != null) downloadParams.JG_CHASU = String(chasu);
 
-  return { files, downloadParams };
+  return { files, downloadParams, rounds };
 }
 
 function parseFileList(html: string): EvaluationFile[] {
@@ -99,9 +167,10 @@ function parseFileList(html: string): EvaluationFile[] {
   const seen = new Set<string>();
   // <a ... onclick="getEiFile43('5')...">파일명.hwpx(89 KB)</a>
   // 파일명에 괄호가 있을 수 있으므로 앵커(>)와 종료(<) 사이 전체를 잡고, 크기 표기는 선택적.
-  // onclick 따옴표(작은/큰), getEiFile43 인자 공백·따옴표 유무를 모두 허용 (HTML 변형 견고화).
+  // 핸들러명은 항목마다 다르다(4-가=getEiFile43, 2-가=getEiFile14)므로 getEiFile\d*로 일반화.
+  // onclick 따옴표(작은/큰), 인자 공백·따옴표 유무를 모두 허용 (HTML 변형 견고화).
   const re =
-    /onclick=["'][^"']*getEiFile43\(\s*['"]?(\d+)['"]?\s*\)[^"']*["'][^>]*>\s*([^<]*?\.(?:hwpx|hwp|pdf|docx|xlsx))\s*(?:\(\s*([\d.,]+)\s*([KM]B)\s*\))?/gi;
+    /onclick=["'][^"']*getEiFile\d*\(\s*['"]?(\d+)['"]?\s*\)[^"']*["'][^>]*>\s*([^<]*?\.(?:hwpx|hwp|pdf|docx|xlsx))\s*(?:\(\s*([\d.,]+)\s*([KM]B)\s*\))?/gi;
   let m: RegExpExecArray | null;
   while ((m = re.exec(html))) {
     if (seen.has(m[1])) continue;
@@ -110,7 +179,7 @@ function parseFileList(html: string): EvaluationFile[] {
   }
   // 폴백: 순서 기반 매칭 (onclick과 파일명이 분리된 비표준 구조)
   if (files.length === 0) {
-    const seqs = [...html.matchAll(/getEiFile43\(\s*['"]?(\d+)['"]?\s*\)/g)].map((x) => x[1]);
+    const seqs = [...html.matchAll(/getEiFile\d*\(\s*['"]?(\d+)['"]?\s*\)/g)].map((x) => x[1]);
     const names = [...html.matchAll(/([^>\s][^<>]*?\.(?:hwpx|hwp|pdf|docx|xlsx))\s*(?:\(\s*([\d.,]+)\s*([KM]B)\s*\))?/gi)];
     // 개수가 일치할 때만 신뢰 (어긋나면 seq↔파일명 뒤바뀜 위험)
     if (seqs.length === names.length) {
@@ -136,7 +205,8 @@ function toKB(num?: string, unit?: string): number | undefined {
 function parseDownloadParams(
   html: string,
   shlIdfCd: string,
-  year: number
+  year: number,
+  spec: DisclosureItemSpec
 ): Record<string, string> {
   const params: Record<string, string> = {};
   const formIdx = html.indexOf("eiFileDownForm");
@@ -154,9 +224,9 @@ function parseDownloadParams(
   }
   // 필수값 보강
   params.SHL_IDF_CD ??= shlIdfCd;
-  params.JG_BURYU_CD ??= EVAL_ITEM.JG_BURYU_CD;
-  params.JG_HANGMOK_CD ??= EVAL_ITEM.JG_HANGMOK_CD;
-  params.JG_GUBUN ??= EVAL_ITEM.JG_GUBUN;
+  params.JG_BURYU_CD ??= spec.codes.JG_BURYU_CD;
+  params.JG_HANGMOK_CD ??= spec.codes.JG_HANGMOK_CD;
+  params.JG_GUBUN ??= spec.codes.JG_GUBUN;
   params.JG_YEAR ??= String(year);
   params.JG_CHASU ??= "1";
   params.PRE_JG_YEAR ??= String(year);
@@ -166,12 +236,13 @@ function parseDownloadParams(
 /** 특정 첨부파일 다운로드 (GET EiFileDownLoad) */
 export async function downloadEvaluationFile(
   downloadParams: Record<string, string>,
-  seq: string
+  seq: string,
+  spec: DisclosureItemSpec = EVAL_ITEM_SPEC
 ): Promise<{ buffer: ArrayBuffer; filename: string }> {
   if (!/^\d+$/.test(seq)) throw new Error("잘못된 파일 식별자입니다.");
   const qs = new URLSearchParams({ ...downloadParams, FILE_SEQ: seq });
   const res = await fetchT(`${BASE}/servlets/EiFileDownLoad.do?${qs}`, {
-    headers: { "User-Agent": UA, Referer: `${BASE}/ei/pp/Pneipp_b43_s0p.do` },
+    headers: { "User-Agent": UA, Referer: `${BASE}/ei/pp/${spec.endpoint}` },
   });
   if (!res.ok) throw new Error(`HTTP ${res.status} — 파일 다운로드 실패`);
   // 크기 상한 — Content-Length 선검사 + 실제 바이트 재확인
@@ -203,25 +274,65 @@ export interface EvaluationResult {
 }
 
 /**
+ * 같은 해에 제출된 회차들 중 학기를 판단한다.
+ * 관찰된 패턴(1차=4월=1학기, 3차=9월=2학기)을 하드코딩하지 않고,
+ * 그 해의 최소 chasu를 1학기, 최대 chasu를 2학기로 취급한다 — 회차 번호 자체가
+ * 학교/연도마다 다를 수 있어(정정 회차 등) 상대적 순서로 판단하는 편이 안전하다.
+ */
+function roundForSemester(rounds: SubmissionRound[], year: number, semester: 1 | 2): SubmissionRound | undefined {
+  const ofYear = rounds.filter((r) => r.year === year).sort((a, b) => a.chasu - b.chasu);
+  if (!ofYear.length) return undefined;
+  if (semester === 1) return ofYear[0];
+  // 2학기: 그 해에 회차가 2개 이상 있어야 함(1개뿐이면 아직 2학기 자료가 없다는 뜻)
+  return ofYear.length > 1 ? ofYear[ofYear.length - 1] : undefined;
+}
+
+/**
  * 평가계획 첨부파일 목록을 수행평가 관련성 순으로 정렬해 반환한다 (다운로드/파싱 전).
  * 과목별로 쪼개진 학교(과목별 PDF 여러 개)는 목록을 먼저 보여주고 선택하게 하기 위함.
+ *
+ * @param semester 1(1학기) | 2(2학기) 지정 시, 그 학기에 해당하는 제출 회차를 찾아 재조회한다.
+ *   해당 학기 자료가 아직 없으면(예: 연중 2학기 미제출) 명시적으로 에러를 던진다 — 엉뚱한
+ *   학기 자료를 조용히 대신 반환하지 않는다.
  */
 export async function listEvaluationDocs(
   school: School,
-  year?: number
-): Promise<{ docs: EvaluationFile[]; downloadParams: Record<string, string>; year: number }> {
+  year?: number,
+  spec: DisclosureItemSpec = EVAL_ITEM_SPEC,
+  semester?: 1 | 2
+): Promise<{ docs: EvaluationFile[]; downloadParams: Record<string, string>; year: number; chasu?: number; rounds: SubmissionRound[] }> {
   // 연도 미지정 시: 올해 → (연초엔 신학년도 평가계획이 아직 미공시이므로) 작년 순으로 자동 폴백.
   // 사용자가 연도를 명시하면 그 해만 조회 (임의 폴백 금지).
   const thisYear = new Date().getFullYear();
   const candidates = year != null ? [year] : [thisYear, thisYear - 1];
   for (const y of candidates) {
-    const { files, downloadParams } = await fetchEvaluationFiles(school.shlIdfCd, school.name, y);
-    if (files.length) {
-      const docs = files
-        .filter((f) => /\.(hwpx|hwp|pdf|docx)$/i.test(f.filename))
-        .sort((a, b) => evalScore(a.filename) - evalScore(b.filename));
-      return { docs: docs.length ? docs : files, downloadParams, year: y };
+    let { files, downloadParams, rounds } = await fetchEvaluationFiles(school.shlIdfCd, school.name, y, spec);
+    if (!files.length) continue;
+
+    let chasu: number | undefined;
+    if (semester != null) {
+      const target = roundForSemester(rounds, y, semester);
+      if (!target) {
+        // 연도 폴백 없이(임의 학기 대체 금지) 다음 연도 후보로 넘어가되, 마지막까지 못 찾으면 아래에서 에러.
+        if (y === candidates[candidates.length - 1]) {
+          const available = rounds.filter((r) => r.year === y).map((r) => r.label).join(", ") || "없음";
+          throw new Error(
+            `${y}년 ${semester}학기 평가계획 자료가 아직 제출되지 않았습니다. (${y}년 제출 회차: ${available})`
+          );
+        }
+        continue;
+      }
+      chasu = target.chasu;
+      // 이미 그 회차가 기본으로 로드돼 있으면 재요청 생략
+      if (!target.selected) {
+        ({ files, downloadParams, rounds } = await fetchEvaluationFiles(school.shlIdfCd, school.name, y, spec, chasu));
+      }
     }
+
+    const docs = files
+      .filter((f) => /\.(hwpx|hwp|pdf|docx)$/i.test(f.filename))
+      .sort((a, b) => spec.score(a.filename) - spec.score(b.filename));
+    return { docs: docs.length ? docs : files, downloadParams, year: y, chasu, rounds };
   }
   throw new Error(
     `${candidates.join("·")}년도 평가계획 첨부파일을 찾지 못했습니다. (다른 연도를 지정하거나 ${DISCLOSURE_PORTAL} 직접 확인)`
@@ -231,9 +342,10 @@ export async function listEvaluationDocs(
 /** 특정 첨부파일을 다운로드 + kordoc 파싱 */
 export async function fetchEvaluationBySeq(
   downloadParams: Record<string, string>,
-  file: EvaluationFile
+  file: EvaluationFile,
+  spec: DisclosureItemSpec = EVAL_ITEM_SPEC
 ): Promise<EvaluationResult> {
-  const { buffer, filename } = await downloadEvaluationFile(downloadParams, file.seq);
+  const { buffer, filename } = await downloadEvaluationFile(downloadParams, file.seq, spec);
   // filePath를 넘기지 않는다: 다운로드 파일명은 디스크에 없는 가짜 경로라
   // kordoc의 배포용 HWP COM 폴백이 존재하지 않는 파일을 열려 시도할 수 있음.
   // 포맷은 매직바이트로 자동 감지되므로 ArrayBuffer만으로 충분.
@@ -243,7 +355,7 @@ export async function fetchEvaluationBySeq(
     filename: filename || file.filename,
     fileType: parsed.fileType ?? "unknown",
     markdown,
-    evaluationSections: extractEvaluationSections(markdown),
+    evaluationSections: extractEvaluationSections(markdown, spec.sectionKeywords),
   };
 }
 
@@ -252,21 +364,23 @@ export async function fetchEvaluationBySeq(
  * - 기본: 우선순위 1순위 파일 1개
  * - opts.all: 전체 과목 파일
  * - opts.seq: 특정 파일만 (과목 선택)
+ * - opts.semester: 1(1학기)|2(2학기) — 해당 학기 제출 회차로 재조회
  */
 export async function autoFetchEvaluation(
   school: School,
   year?: number,
-  opts: { all?: boolean; seq?: string } = {}
+  opts: { all?: boolean; seq?: string; semester?: 1 | 2 } = {},
+  spec: DisclosureItemSpec = EVAL_ITEM_SPEC
 ): Promise<EvaluationResult[]> {
-  const { docs, downloadParams } = await listEvaluationDocs(school, year);
+  const { docs, downloadParams } = await listEvaluationDocs(school, year, spec, opts.semester);
 
   if (opts.seq) {
     const f = docs.find((d) => d.seq === opts.seq);
-    return f ? [await fetchEvaluationBySeq(downloadParams, f)] : [];
+    return f ? [await fetchEvaluationBySeq(downloadParams, f, spec)] : [];
   }
   if (opts.all) {
     const results: EvaluationResult[] = [];
-    for (const f of docs.slice(0, MAX_ALL_DOCS)) results.push(await fetchEvaluationBySeq(downloadParams, f));
+    for (const f of docs.slice(0, MAX_ALL_DOCS)) results.push(await fetchEvaluationBySeq(downloadParams, f, spec));
     if (docs.length > MAX_ALL_DOCS) {
       results.push({
         filename: `(이하 ${docs.length - MAX_ALL_DOCS}개 파일 생략)`,
@@ -280,7 +394,7 @@ export async function autoFetchEvaluation(
   // 기본: 우선순위대로 시도하되, 이미지 PDF 등으로 내용이 빈약하면 다음 파일로 폴백
   let best: EvaluationResult | null = null;
   for (const f of docs.slice(0, 6)) {
-    const r = await fetchEvaluationBySeq(downloadParams, f);
+    const r = await fetchEvaluationBySeq(downloadParams, f, spec);
     if (r.markdown.trim().length >= MIN_USEFUL_MD) return [r];
     if (!best) best = r;
   }
@@ -293,6 +407,19 @@ export async function autoFetchEvaluation(
 function evalScore(filename: string): number {
   if (/교수.?학습|평가\s*계획|평가\s*운영/.test(filename)) return 0;
   if (/학업성적관리/.test(filename)) return 2;
+  return 1;
+}
+
+/**
+ * 파일명 기반 교육과정 편제표 관련성 점수 (낮을수록 우선).
+ * 2-가 항목엔 '편제표 본문'과 '연간학사일정'이 함께 올라오는 경우가 많아,
+ * 학사일정류를 후순위로 밀고 교육과정/교육계획 문서를 우선 선택한다.
+ * 공백 변형("교육 계획" vs "교육계획서")을 흡수하려 공백을 제거하고 매칭.
+ */
+function curriculumScore(filename: string): number {
+  const n = filename.replace(/\s/g, "");
+  if (/연간학사일정|학사일정/.test(n)) return 3; // 학사 캘린더 — 편제표 아님
+  if (/(학교)?교육과정|교육계획/.test(n)) return 0; // 편제표 본문
   return 1;
 }
 
@@ -326,12 +453,11 @@ export async function parseEvaluationDocument(
 }
 
 /** 마크다운에서 수행평가/평가 관련 구간 추출 */
-export function extractEvaluationSections(markdown: string): string[] {
-  const KEYWORDS = ["수행평가", "평가기준", "평가요소", "평가방법", "평가영역", "반영비율", "평가시기", "성취기준", "지필", "정기시험"];
+export function extractEvaluationSections(markdown: string, keywords: string[] = EVAL_SECTION_KEYWORDS): string[] {
   const blocks = markdown.split(/\n\s*\n/);
   const hits: string[] = [];
   for (const block of blocks) {
-    if (KEYWORDS.some((k) => block.includes(k))) hits.push(block.trim());
+    if (keywords.some((k) => block.includes(k))) hits.push(block.trim());
   }
   return hits;
 }

--- a/src/evaluation.ts
+++ b/src/evaluation.ts
@@ -411,6 +411,16 @@ function evalScore(filename: string): number {
 }
 
 /**
+ * 파일명에서 학년을 추출한다 (예: "...3학년 전과목...hwp" → 3).
+ * 1~3학년 통합본처럼 학년 표기가 없는 파일(단일 첨부, 전학년 합본)은 null —
+ * 이 경우 학년으로 거를 대상이 없다는 뜻이므로 그대로 통과시켜야 한다.
+ */
+export function gradeInFilename(filename: string): number | null {
+  const m = filename.match(/([1-6])\s*학년/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
  * 파일명 기반 교육과정 편제표 관련성 점수 (낮을수록 우선).
  * 2-가 항목엔 '편제표 본문'과 '연간학사일정'이 함께 올라오는 경우가 많아,
  * 학사일정류를 후순위로 밀고 교육과정/교육계획 문서를 우선 선택한다.

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -27,6 +27,8 @@ import {
   parseEvaluationDocument,
   autoFetchEvaluation,
   listEvaluationDocs,
+  EVAL_ITEM_SPEC,
+  CURRICULUM_ITEM_SPEC,
 } from "./evaluation.js";
 import {
   findAdmissionUniversity,
@@ -428,11 +430,13 @@ export function buildMcpServer(opts: { localFiles?: boolean } = {}): McpServer {
       kind: z.enum(KINDS),
       name: z.string().describe("학교명"),
       year: z.number().optional().describe("공시연도 (기본: 올해)"),
+      semester: z.union([z.literal(1), z.literal(2)]).optional()
+        .describe("1(1학기)|2(2학기) — 자료제출일(회차) 기준으로 해당 학기 자료를 찾음. 미지정 시 최신 제출분(보통 1학기)."),
       subject: z.string().optional().describe("과목/파일명 키워드 (과목별로 나뉜 학교에서 특정 과목 선택)"),
       all: z.boolean().optional().describe("true면 전체 과목 파일을 모두 조회"),
       full: z.boolean().optional().describe("true면 전체 문서, 기본은 수행평가 섹션 위주"),
     },
-    async ({ sido, sgg, kind, name, year, subject, all, full }) => {
+    async ({ sido, sgg, kind, name, year, semester, subject, all, full }) => {
       try {
         const client = getClient();
         const { school, many } = await resolveSchool(client, sido, sgg, kind, name);
@@ -440,18 +444,22 @@ export function buildMcpServer(opts: { localFiles?: boolean } = {}): McpServer {
         if (!school) return ok(`학교를 찾을 수 없습니다: ${name}`);
 
         // 과목별로 나뉜 학교는 목록을 먼저 안내 (subject/all 미지정 시)
-        const { docs } = await listEvaluationDocs(school, year);
+        const { docs, year: usedYear, chasu, rounds } = await listEvaluationDocs(school, year, EVAL_ITEM_SPEC, semester);
+        const roundNote = chasu != null
+          ? `\n> 자료제출일: ${rounds.find((r) => r.year === usedYear && r.chasu === chasu)?.label ?? `${usedYear}년 ${chasu}차`}`
+          : "";
         if (docs.length > 1 && !subject && !all) {
           const lines = docs.map((d) => `- ${d.filename}${d.sizeKB ? ` (${d.sizeKB}KB)` : ""}`);
           return ok(
-            `# ${school.name} — 평가계획 파일이 ${docs.length}개 있습니다 (과목별)\n\n` +
+            `# ${school.name} — 평가계획 파일이 ${docs.length}개 있습니다 (과목별)${roundNote}\n\n` +
               lines.join("\n") +
-              `\n\n특정 과목은 subject="국어"처럼, 전체는 all=true로 다시 요청하세요.`
+              `\n\n특정 과목은 subject="국어"처럼, 전체는 all=true로 다시 요청하세요.` +
+              (semester == null ? `\n다른 학기는 semester=1 또는 semester=2로 요청하세요.` : "")
           );
         }
         const seq = subject ? docs.find((d) => d.filename.includes(subject))?.seq : undefined;
-        const results = await autoFetchEvaluation(school, year, { all: !!all, seq });
-        const parts: string[] = [`# ${school.name} — 교수·학습 및 평가 운영 계획\n`];
+        const results = await autoFetchEvaluation(school, year, { all: !!all, seq, semester });
+        const parts: string[] = [`# ${school.name} — 교수·학습 및 평가 운영 계획${roundNote}\n`];
         for (const r of results) {
           parts.push(`## 📄 ${r.filename} (${r.fileType})\n`);
           if (r.evaluationSections.length) {
@@ -468,6 +476,68 @@ export function buildMcpServer(opts: { localFiles?: boolean } = {}): McpServer {
         return ok(parts.join("\n"));
       } catch (e: any) {
         // 자동 다운로드 실패 시 수동 안내로 폴백
+        try {
+          const client = getClient();
+          const { school } = await resolveSchool(client, sido, sgg, kind, name);
+          if (school) return ok(`⚠️ 자동 조회 실패: ${e.message}\n\n` + evaluationGuide(school, year));
+        } catch {}
+        return err(`오류: ${e.message}`);
+      }
+    }
+  );
+
+  // ─── 5-2. 교육과정 편제표(2-가) 자동 조회 ────────────────
+  server.tool(
+    "get_curriculum_plan",
+    "학교의 '학교교육과정 편성·운영 및 평가에 관한 사항'(2-가) 첨부문서를 학교알리미에서 자동으로 내려받아 마크다운으로 변환하고 교육과정 편제표(교과(군)별 이수단위/시간 배당)를 추출합니다. 특정 학년도 입학생 기준 편제는 year에 그 입학연도를 지정하세요.",
+    {
+      sido: z.string(),
+      sgg: z.string(),
+      kind: z.enum(KINDS),
+      name: z.string().describe("학교명"),
+      year: z.number().optional().describe("공시연도/입학연도 (기본: 올해)"),
+      subject: z.string().optional().describe("파일명 키워드 (한 항목에 파일이 여러 개일 때 특정 문서 선택)"),
+      all: z.boolean().optional().describe("true면 항목의 전체 첨부파일을 모두 조회"),
+      full: z.boolean().optional().describe("true면 전체 문서, 기본은 편제 관련 섹션 위주"),
+    },
+    async ({ sido, sgg, kind, name, year, subject, all, full }) => {
+      try {
+        const client = getClient();
+        const { school, many } = await resolveSchool(client, sido, sgg, kind, name);
+        if (many) return ok(`여러 학교가 검색됨:\n` + many.map((s) => `- ${s.name}`).join("\n"));
+        if (!school) return ok(`학교를 찾을 수 없습니다: ${name}`);
+
+        // 2-가 항목엔 편제표 + 연간학사일정이 섞여 올라오므로, 목록을 나열하기보다
+        // 점수(curriculumScore)로 편제표 문서를 자동 선택한다. (subject/all로 수동 지정 가능)
+        const { docs } = await listEvaluationDocs(school, year, CURRICULUM_ITEM_SPEC);
+        const seq = subject ? docs.find((d) => d.filename.includes(subject))?.seq : undefined;
+        if (subject && !seq) return ok(`"${subject}"에 해당하는 파일을 찾을 수 없습니다. 파일 목록:\n` + docs.map((d) => `- ${d.filename}`).join("\n"));
+        const results = await autoFetchEvaluation(school, year, { all: !!all, seq }, CURRICULUM_ITEM_SPEC);
+        const parts: string[] = [`# ${school.name} — 학교교육과정 편성·운영 및 평가\n`];
+        for (const r of results) {
+          parts.push(`## 📄 ${r.filename} (${r.fileType})\n`);
+          if (r.evaluationSections.length) {
+            parts.push(`### 🎯 교육과정 편제 관련 (${r.evaluationSections.length}개)\n`);
+            parts.push(r.evaluationSections.join("\n\n---\n\n"));
+          }
+          if (r.needsOcr) {
+            parts.push(`\n> ⚠️ 본문 추출이 빈약합니다(이미지 PDF 추정). 원본 직접 확인을 권장합니다.\n`, evaluationGuide(school, year));
+          }
+          if (full || !r.evaluationSections.length) {
+            parts.push(`\n### 전체 문서\n`, r.markdown);
+          }
+        }
+        // 편제표 외 파일(연간학사일정 등)이 더 있으면 안내
+        if (!all && !subject && docs.length > 1) {
+          parts.push(
+            `\n---\n> 이 항목엔 첨부파일이 ${docs.length}개 있어 편제표로 추정되는 문서를 자동 선택했습니다.\n` +
+              `> 전체 목록:\n` + docs.map((d) => `> - ${d.filename}${d.sizeKB ? ` (${d.sizeKB}KB)` : ""}`).join("\n") +
+              `\n> 다른 파일은 subject="키워드", 전체는 all=true로 요청하세요.`
+          );
+        }
+        return ok(parts.join("\n"));
+      } catch (e: any) {
+        // 자동 조회 실패 시 수동 안내로 폴백
         try {
           const client = getClient();
           const { school } = await resolveSchool(client, sido, sgg, kind, name);

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -27,8 +27,11 @@ import {
   parseEvaluationDocument,
   autoFetchEvaluation,
   listEvaluationDocs,
+  gradeInFilename,
+  structureEvaluation,
   EVAL_ITEM_SPEC,
   CURRICULUM_ITEM_SPEC,
+  type EvaluationFile,
 } from "./evaluation.js";
 import {
   findAdmissionUniversity,
@@ -432,33 +435,80 @@ export function buildMcpServer(opts: { localFiles?: boolean } = {}): McpServer {
       year: z.number().optional().describe("공시연도 (기본: 올해)"),
       semester: z.union([z.literal(1), z.literal(2)]).optional()
         .describe("1(1학기)|2(2학기) — 자료제출일(회차) 기준으로 해당 학기 자료를 찾음. 미지정 시 최신 제출분(보통 1학기)."),
-      subject: z.string().optional().describe("과목/파일명 키워드 (과목별로 나뉜 학교에서 특정 과목 선택)"),
+      subject: z.string().optional().describe("과목명(예: '국어', '공통국어2'). 파일명이 아니라 문서 '내용'에서 해당 과목의 평가표를 찾아 그 부분만 반환한다. 학년·전과목 통합본 학교에서도 동작."),
+      grade: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5), z.literal(6)]).optional()
+        .describe("학년(1~6) — 첨부파일이 학년별로 나뉜 학교(예: '...3학년 전과목...')에서 어느 파일을 받을지 고를 때만 씀. 1~3학년을 한 파일에 합본한 학교엔 파일명에 학년 표기가 없어 영향 없음(어차피 파일이 하나라 그대로 받아옴)."),
       all: z.boolean().optional().describe("true면 전체 과목 파일을 모두 조회"),
       full: z.boolean().optional().describe("true면 전체 문서, 기본은 수행평가 섹션 위주"),
     },
-    async ({ sido, sgg, kind, name, year, semester, subject, all, full }) => {
+    async ({ sido, sgg, kind, name, year, semester, subject, grade, all, full }) => {
       try {
         const client = getClient();
         const { school, many } = await resolveSchool(client, sido, sgg, kind, name);
         if (many) return ok(`여러 학교가 검색됨:\n` + many.map((s) => `- ${s.name}`).join("\n"));
         if (!school) return ok(`학교를 찾을 수 없습니다: ${name}`);
 
-        // 과목별로 나뉜 학교는 목록을 먼저 안내 (subject/all 미지정 시)
         const { docs, year: usedYear, chasu, rounds } = await listEvaluationDocs(school, year, EVAL_ITEM_SPEC, semester);
         const roundNote = chasu != null
           ? `\n> 자료제출일: ${rounds.find((r) => r.year === usedYear && r.chasu === chasu)?.label ?? `${usedYear}년 ${chasu}차`}`
           : "";
-        if (docs.length > 1 && !subject && !all) {
+        // 첨부파일명에는 과목명이 안 들어간다(전과목 통합본이 흔함) — 파일명으로 쓸모 있는
+        // 정보는 (a) 파일이 몇 개인지, (b) 학년 표기뿐이다. 그래서 파일 선택은 grade로만 하고,
+        // 과목(subject)은 파일을 받은 뒤 "내용"에서 찾는다(아래 structureEvaluation).
+        const picked: EvaluationFile | undefined = docs.length > 1
+          ? (grade != null ? docs.find((d) => gradeInFilename(d.filename) === grade) : undefined)
+          : docs[0];
+        if (docs.length > 1 && !all && !picked) {
           const lines = docs.map((d) => `- ${d.filename}${d.sizeKB ? ` (${d.sizeKB}KB)` : ""}`);
+          const hasGradeSplit = docs.some((d) => gradeInFilename(d.filename) != null);
           return ok(
-            `# ${school.name} — 평가계획 파일이 ${docs.length}개 있습니다 (과목별)${roundNote}\n\n` +
+            `# ${school.name} — 평가계획 파일이 ${docs.length}개 있습니다${roundNote}\n\n` +
               lines.join("\n") +
-              `\n\n특정 과목은 subject="국어"처럼, 전체는 all=true로 다시 요청하세요.` +
+              (hasGradeSplit
+                ? `\n\n학년별 파일이 나뉘어 있습니다. grade=1|2|3처럼 지정하세요.`
+                : `\n\n어느 파일인지 특정할 수 없습니다.`) +
+              ` 과목은 grade로 파일을 고른 뒤 subject="국어"처럼 내용에서 찾습니다. 전체는 all=true로 요청하세요.` +
               (semester == null ? `\n다른 학기는 semester=1 또는 semester=2로 요청하세요.` : "")
           );
         }
-        const seq = subject ? docs.find((d) => d.filename.includes(subject))?.seq : undefined;
+        const targetGrade = grade ?? (picked ? gradeInFilename(picked.filename) : null);
+        const seq = all ? undefined : picked?.seq;
         const results = await autoFetchEvaluation(school, year, { all: !!all, seq, semester });
+
+        // subject가 주어지면 문서 내용을 구조화해 해당 과목의 평가표만 골라낸다.
+        // (전과목 통합본이 아니라 애초에 과목 하나짜리 문서면 structureEvaluation이 null을 반환하고
+        //  아래는 그냥 건너뛰어, 기존 evaluationSections(키워드 블록 추출) 결과가 그대로 쓰인다.)
+        if (subject && !all && results.length === 1) {
+          const structured = structureEvaluation(results[0].markdown);
+          if (structured) {
+            const gradeEntry = targetGrade != null
+              ? structured.grades.find((g) => g.grade === targetGrade)
+              : (structured.grades.length === 1 ? structured.grades[0] : undefined);
+            if (!gradeEntry && structured.grades.length > 1) {
+              // 1~N학년을 한 파일에 합본한 학교(파일명엔 학년 표기가 없음) — 문서 안에는
+              // 학년별 종합표가 여러 개라 grade 없이는 어느 학년의 과목인지 특정할 수 없다.
+              return ok(
+                `이 문서는 여러 학년을 합본하고 있어 grade 없이는 "${subject}" 과목을 특정할 수 없습니다.\n` +
+                  structured.grades.map((g) => `- ${g.label || `${g.grade}학년`}: ${g.subjects.join(", ")}`).join("\n") +
+                  `\n\ngrade=1|2|3처럼 지정해 다시 요청하세요.`
+              );
+            }
+            if (gradeEntry) {
+              const subjKey = Object.keys(gradeEntry.details ?? {}).find(
+                (k) => subject.includes(k) || k.includes(subject)
+              );
+              if (subjKey && gradeEntry.details?.[subjKey]) {
+                results[0] = { ...results[0], evaluationSections: [gradeEntry.details[subjKey]] };
+              } else {
+                return ok(
+                  `"${subject}" 과목을 ${school.name}${roundNote} 문서(${gradeEntry.label || "학년 미상"})에서 찾지 못했습니다.\n` +
+                    `문서에 있는 과목: ${gradeEntry.subjects.join(", ") || "(없음)"}`
+                );
+              }
+            }
+          }
+        }
+
         const parts: string[] = [`# ${school.name} — 교수·학습 및 평가 운영 계획${roundNote}\n`];
         for (const r of results) {
           parts.push(`## 📄 ${r.filename} (${r.fileType})\n`);


### PR DESCRIPTION
## 무엇을 / 왜

`get_evaluation_plan`(교과별 교수·학습 및 평가 운영 계획 조회)에 **학기·학년·과목 지정**을 추가합니다. 학교알리미 평가계획 첨부파일은 대개 **전과목 통합본**이라, 기존에는 원하는 학기/학년/과목만 콕 집어 받기 어려웠습니다. 이 PR은 그걸 가능하게 합니다.

## 추가된 파라미터 (모두 선택적 — 기존 동작 100% 호환)

- **`semester` (1|2)** — 자료제출일(회차) 드롭다운을 파싱해 해당 학기 제출분을 찾아 조회. 미지정 시 기존처럼 최신 제출분. 해당 학기 자료가 아직 없으면 명확한 에러 반환.
- **`grade` (1~6)** — 첨부파일이 학년별로 나뉜 학교에서 어느 파일을 받을지 선택. 파일명에 학년 표기가 있는 경우에만 사용(합본 학교엔 영향 없음).
- **`subject` (예: "공통국어2")** — **파일명이 아니라 문서 "내용"에서** 해당 과목의 평가표를 찾아 그 부분만 반환. 전과목 통합본에서도 동작.

## 핵심 설계 메모

- 첨부파일명에는 과목명이 없고 학년 표기만 있는 경우가 흔함 → **파일 선택은 `grade`로, 과목은 받은 문서 내용에서 `structureEvaluation`으로** 찾는 2단계 접근.
- 학기 판단은 회차 번호를 하드코딩하지 않고 "그 해 최소 회차=1학기, 최대 회차=2학기"로 일반화(정정 회차 등 대비).

## 변경 범위

- `src/evaluation.ts`: `SubmissionRound`/`parseSubmissionRounds`/`roundForSemester`/`gradeInFilename` 추가, `listEvaluationDocs`·`autoFetchEvaluation`에 `semester` 파라미터.
- `src/mcpServer.ts`: `get_evaluation_plan` 도구에 `semester`/`grade`/`subject` 파라미터 + 학년별 파일 안내 메시지.

## 호환성 / 테스트

- 새 파라미터는 전부 optional이라 **기존 호출은 그대로 동작**합니다.
- `npm test` 전체 통과(32/32).

작지만 실사용에서 유용해 공유합니다. 검토 감사합니다! 🙏
