### PR TITLE
fix(mcp): GET /mcp 에 405 반환 — SSE 스트림 미제공 명시 (Antigravity 연결 행 해소)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -178,6 +178,28 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, mcp-protocol-version, authorization");
       res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
       if (req.method === "OPTIONS") return res.writeHead(204).end();
+      // GET(서버→클라이언트 SSE 스트림)은 지원하지 않는다.
+      //  이 엔드포인트는 stateless라 서버가 먼저 보낼 메시지가 없다. 그런데 SDK의
+      //  handleGetRequest는 GET을 받으면 아무것도 보내지 않는 SSE 스트림을 열고 닫지 않아,
+      //  스트림을 여는 클라이언트(예: Google Antigravity)가 "연결 중"에서 멈춘다.
+      //  MCP 규격은 이 경우 405를 반환하도록 정하고 있다.
+      //  https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+      //  > The server MUST either return Content-Type: text/event-stream in response to
+      //  > this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the
+      //  > server does not offer an SSE stream at this endpoint.
+      if (req.method === "GET") {
+        res.writeHead(405, {
+          "Content-Type": "application/json; charset=utf-8",
+          Allow: "POST, DELETE, OPTIONS",
+        });
+        return res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32000, message: "Method Not Allowed: this endpoint does not offer an SSE stream" },
+            id: null,
+          }),
+        );
+      }
       if (rateLimited(clientIp(req), now)) {
         res.writeHead(429, { "Content-Type": "application/json; charset=utf-8" });
         return res.end(JSON.stringify({ error: "요청이 너무 많습니다." }));


### PR DESCRIPTION
Fixes #3

## 문제

`GET /mcp` 가 응답도 거절도 하지 않아, 스트림을 여는 클라이언트가 무기한 대기합니다.
Google Antigravity 2.4.3 에서 17분간 `still connecting` 상태가 지속되고 타임아웃도 걸리지 않습니다.

```
mcp_manager.go:797] MCP: 1 server(s) still connecting after 17m0s: schoolinfo
```

## 원인

이 엔드포인트는 `sessionIdGenerator: undefined` 인 **stateless** 구성이라 서버가 먼저 보낼 메시지가 없습니다.
그런데 GET 을 SDK 트랜스포트에 그대로 넘기면, `handleGetRequest` 가 **아무것도 보내지 않는 SSE 스트림을 열고 닫지 않습니다.**

`@modelcontextprotocol/sdk` 1.30.0 / `server/webStandardStreamableHttp.js`:

```js
async handleGetRequest(req) {
    // ... accept / session / protocol 검사 통과 후
    const readable = new ReadableStream({
        start: controller => { streamController = controller; },
        ...
    });
    // 서버가 보낼 메시지가 없으면 이 스트림은 계속 열려 있음
}
```

## 수정

GET 을 트랜스포트에 넘기기 전에 `405 Method Not Allowed` 로 응답합니다.

MCP 규격이 이 경우를 명시하고 있습니다 — [Transports (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports):

> The server **MUST** either return `Content-Type: text/event-stream` in response to this HTTP GET,
> **or else return HTTP 405 Method Not Allowed**, indicating that the server does not offer an SSE stream at this endpoint.

같은 저장소 계열의 `/stats`, `/law` 엔드포인트는 이미 405 를 반환하고 있어 동작이 일치하게 됩니다.

## 검증

로컬 빌드 후 `PORT=8791 node dist/server.js` 로 확인했습니다.

**수정 전**

```
GET  https://mcp.gomdori.app/school   무응답 (12s 타임아웃)
GET  https://mcp.gomdori.app/stats    405 Method Not Allowed (0.18s)
GET  https://mcp.gomdori.app/law      405 Method Not Allowed (0.22s)
```

**수정 후 (로컬)**

```
GET  /mcp              405  0.01s   Allow: POST, DELETE, OPTIONS
     body: {"jsonrpc":"2.0","error":{"code":-32000,
            "message":"Method Not Allowed: this endpoint does not offer an SSE stream"},"id":null}

POST /mcp initialize   200  0.01s   schoolinfo-mcp
POST /mcp tools/list   200  0.00s   도구 14개
```

POST 경로는 회귀 없이 그대로 동작합니다. `OPTIONS`(CORS preflight)와 `DELETE` 도 기존과 동일합니다.

## 참고

교사 대상 연수에서 `get_evaluation_plan` 을 실습에 쓰려고 준비하다 발견했습니다.
현재는 `mcp-remote` 브리지(POST 전용)로 우회하면 정상 동작하지만, Node.js 가 필요해 일반 사용자에게는 권하기 어렵습니다.
이 수정이 반영되면 `serverUrl` 한 줄로 바로 연결됩니다.

좋은 도구 만들어주셔서 감사합니다.
