### PR TITLE
fix(mcp): CORS Allow-Methods에서 GET 제거 — 405 응답의 Allow와 일치

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -174,7 +174,7 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       // 웹 기반 MCP 클라이언트(claude.ai 등) 대비 CORS (Origin이 있을 때만 반사, 와일드카드 폴백 없음)
       if (req.headers.origin) res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
       res.setHeader("Vary", "Origin");
-      res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+      res.setHeader("Access-Control-Allow-Methods", "POST, DELETE, OPTIONS");
       res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, mcp-protocol-version, authorization");
       res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
       if (req.method === "OPTIONS") return res.writeHead(204).end();


### PR DESCRIPTION
#4 후속 정리입니다.

## 문제

#4 에서 `GET /mcp` 를 405로 거절하게 됐는데, preflight 의 `Access-Control-Allow-Methods` 는 여전히 GET 을 허용한다고 광고하고 있었습니다. 같은 응답 안에서 두 헤더가 어긋납니다.

```
Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS   ← GET 허용이라고 광고
Allow: POST, DELETE, OPTIONS                                ← GET 제외
```

브라우저 기반 MCP 클라이언트가 preflight 만 보고 GET SSE 스트림을 시도할 이유가 없도록 광고에서도 GET 을 뺍니다.

## 검증

로컬 빌드 후 `PORT=8792 node dist/server.js` 로 확인했습니다.

```
OPTIONS /mcp   204   Access-Control-Allow-Methods: POST, DELETE, OPTIONS
GET     /mcp   405   Access-Control-Allow-Methods: POST, DELETE, OPTIONS
                     Allow: POST, DELETE, OPTIONS          ← 이제 일치
POST    /mcp   200   initialize 정상 (protocolVersion 2025-06-18)
```

테스트 33개 전부 통과. 동작 변화는 없습니다 — GET 은 #4 로 이미 405 입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)